### PR TITLE
versions.tf: hcloud_provider version range

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.23.0"
+      version = ">= 1.23, < 2"
     }
     ct = {
       source  = "poseidon/ct"


### PR DESCRIPTION
Allow modules importing this module to use higher version of the
hcloud_provider.
